### PR TITLE
Default to grabbing the username of the user running the process

### DIFF
--- a/lib/proxyagent/agent_manager.go
+++ b/lib/proxyagent/agent_manager.go
@@ -25,12 +25,12 @@ type AgentConfig struct {
 }
 
 // DefaultPrincipal returns the username of the user that invoked the calling process
-func DefaultPrincipal() []string {
+func DefaultPrincipal() string {
 	currentUser, err := user.Current()
 	if err != nil {
-		return []string{os.Getenv("USER")}
+		return os.Getenv("USER")
 	}
-	return []string{currentUser.Username}
+	return currentUser.Username
 }
 
 func SetupAgent(config AgentConfig) (agent.Agent, error) {

--- a/lib/proxyagent/agent_manager.go
+++ b/lib/proxyagent/agent_manager.go
@@ -10,6 +10,7 @@ import (
 	"net"
 	"net/url"
 	"os"
+	"os/user"
 	"strings"
 
 	"golang.org/x/crypto/ssh"
@@ -21,6 +22,15 @@ type AgentConfig struct {
 	GenerateRSAKey  bool
 	ValidPrincipals []string
 	VaultSigningUrl string
+}
+
+// DefaultPrincipal returns the username of the user that invoked the calling process
+func DefaultPrincipal() []string {
+	currentUser, err := user.Current()
+	if err != nil {
+		return []string{os.Getenv("USER")}
+	}
+	return []string{currentUser.Username}
 }
 
 func SetupAgent(config AgentConfig) (agent.Agent, error) {

--- a/root_cli.go
+++ b/root_cli.go
@@ -29,7 +29,7 @@ func init() {
 
 	RootCLI.Flags().BoolVar(&agentConfig.GenerateRSAKey, "generate-key", false, "generate RSA key pair (default: false)")
 	RootCLI.Flags().BoolVar(&agentConfig.DisableProxy, "no-proxy", false, "disable forwarding to an upstream agent (default: false)")
-	RootCLI.Flags().StringSliceVar(&agentConfig.ValidPrincipals, "valid-principals", proxyagent.DefaultPrincipal(), "valid principals for Vault key signing")
+	RootCLI.Flags().StringSliceVar(&agentConfig.ValidPrincipals, "valid-principals", []string{proxyagent.DefaultPrincipal()}, "valid principals for Vault key signing")
 	RootCLI.Flags().StringVar(&agentConfig.VaultSigningUrl, "vault-signing-url", "", "HashiCorp Vault url to sign SSH keys")
 }
 

--- a/root_cli.go
+++ b/root_cli.go
@@ -29,7 +29,7 @@ func init() {
 
 	RootCLI.Flags().BoolVar(&agentConfig.GenerateRSAKey, "generate-key", false, "generate RSA key pair (default: false)")
 	RootCLI.Flags().BoolVar(&agentConfig.DisableProxy, "no-proxy", false, "disable forwarding to an upstream agent (default: false)")
-	RootCLI.Flags().StringSliceVar(&agentConfig.ValidPrincipals, "valid-principals", []string{os.Getenv("USER")}, "valid principals for Vault key signing")
+	RootCLI.Flags().StringSliceVar(&agentConfig.ValidPrincipals, "valid-principals", proxyagent.DefaultPrincipal(), "valid principals for Vault key signing")
 	RootCLI.Flags().StringVar(&agentConfig.VaultSigningUrl, "vault-signing-url", "", "HashiCorp Vault url to sign SSH keys")
 }
 


### PR DESCRIPTION
Exports a 'DefaultPrincipal' function that attempts to return the username of the user that invoked the calling process by calling 'user.Current()' from 'os/user' so that it can be done in a cross-platform way.