### PR TITLE
Update golangci-lint to v1.51 to support Go v1.20

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -24,7 +24,7 @@ jobs:
           go-version: ${{ matrix.go-version }}
       - uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.50
+          version: v1.51
 
   go-test:
     name: go test


### PR DESCRIPTION
With the release of Go v1.20, `golangci-lint` is having trouble linting properly.